### PR TITLE
feat: /brand refresh and /brand/colour-palette implementation

### DIFF
--- a/templates/_layouts/_navigation.html
+++ b/templates/_layouts/_navigation.html
@@ -66,6 +66,9 @@
             <li>
               <a href="/brand/resources" class="p-navigation__dropdown-item">Resources</a>
             </li>
+            <li>
+              <a href="/brand/colour-palette" class="p-navigation__dropdown-item">Colour palette</a>
+            </li>
           </ul>
         </li>
         <li class="p-navigation__item">

--- a/templates/brand/colour-palette.html
+++ b/templates/brand/colour-palette.html
@@ -1,0 +1,707 @@
+{% extends "base.html" %}
+
+{% block title %}Colour palette{% endblock %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block content %}
+  <div class="p-strip is-bordered">
+    <div class="row">
+      <div class="col-8">
+        <img src="https://assets.ubuntu.com/v1/61956028-ubuntu-colour-pantones.jpg"
+             alt="Ubuntu colour pantones"
+             title="Ubuntu colour pantones"
+             width="540"
+             height="247"
+             srcset="https://assets.ubuntu.com/v1/61956028-ubuntu-colour-pantones.jpg 540w,
+                     https://assets.ubuntu.com/v1/cdc130b4-ubuntu-colour-pantones-300x137.jpg 300w"
+             sizes="(max-width: 540px) 100vw,
+                    540px" />
+        <p>
+          Colour is an effective, powerful and instantly recognisable medium for visual communications. To convey the brand personality and brand values, there is a sophisticated colour palette.
+        </p>
+        <p>
+          We have introduced a palette which includes both a fresh, lively orange, and a rich, mature aubergine. The use of aubergine indicates commercial involvement, while orange is a signal of community engagement.
+        </p>
+        <p>These colours are used widely in the brand communications, to convey the precise, reliable and free personality.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip is-bordered">
+    <div class="row">
+      <div class="col-8">
+        <h2>Ubuntu core colours</h2>
+        <p>
+          The Ubuntu colour palette has been created to reflect the spirit of our brand. Orange for a community feel. White for a clean, fresh and light feel.
+        </p>
+        <p>
+          Black is used in some versions of the brandmark for flexibility of application and where print restrictions apply. It can also be used for body copy.
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-4 p-card">
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <svg width="275px"
+             height="128px"
+             viewBox="0 0 275 128"
+             version="1.1"
+             xmlns="http://www.w3.org/2000/svg"
+             xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+          <rect id="path-1" x="0" y="0" width="275" height="128"></rect>
+          </defs>
+          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <use id="Rectangle" mask="url(#mask-2)" fill="#E95420" xlink:href="#path-1"></use>
+          </g>
+        </svg>
+        <h3 class="p-card__title">Ubuntu orange</h3>
+        <h4>Screen</h4>
+        <p class="p-card__content">HEX #E95420</p>
+        <h4>Print</h4>
+        <p class="p-card__content">C0 M79 Y100 K0 (Pantone 1665)</p>
+      </div>
+      <div class="col-4 p-card">
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <svg width="275px"
+             height="128px"
+             viewBox="0 0 275 128"
+             version="1.1"
+             xmlns="http://www.w3.org/2000/svg"
+             xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+          <rect id="path-1" x="0" y="0" width="275" height="128"></rect>
+          </defs>
+          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <use id="Rectangle" mask="url(#mask-2)" fill="#ffffff" xlink:href="#path-1"></use>
+          </g>
+        </svg>
+        <h3 class="p-card__title">White</h3>
+        <h4>Screen</h4>
+        <p class="p-card__content">HEX #FFFFFF</p>
+        <h4>Print</h4>
+        <p>C0 M0 Y0 K0</p>
+      </div>
+      <div class="col-4 p-card">
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <svg width="275px"
+             height="128px"
+             viewBox="0 0 275 128"
+             version="1.1"
+             xmlns="http://www.w3.org/2000/svg"
+             xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+          <rect id="path-1" x="0" y="0" width="275" height="128"></rect>
+          </defs>
+          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <use id="Rectangle" mask="url(#mask-2)" fill="#000000" xlink:href="#path-1"></use>
+          </g>
+        </svg>
+        <h3 class="p-card__title">Black</h3>
+        <h4>Screen</h4>
+        <p class="p-card__content">HEX #000000</p>
+        <h4>Print</h4>
+        <p class="p-card__content">C0 M0 Y0 K100</p>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-8">
+        <div class="p-notification--information">
+          <p class="p-notification__response">
+            <span class="p-notification__status">Information:</span> Pantone Matching System is a worldwide printing, publishing and packaging language for the selection, marketing and control of colour. PANTONE&reg; is a registered trademark of Pantone
+            Inc.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip is-bordered">
+    <div class="row">
+      <div class="col-8">
+        <h2>Supporting colours</h2>
+        <p>In addition, there is a supporting colour palette for when communications have a consumer or enterprise focus.</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item">Light aubergine for a consumer focus</li>
+          <li class="p-list__item">Dark aubergine for an enterprise focus</li>
+          <li class="p-list__item">Mid aubergine for a balance of both</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
+      <div class="col-4 p-card">
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <svg width="275px"
+             height="128px"
+             viewBox="0 0 275 128"
+             version="1.1"
+             xmlns="http://www.w3.org/2000/svg"
+             xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+          <rect id="path-1" x="0" y="0" width="275" height="128"></rect>
+          </defs>
+          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <use id="Rectangle" mask="url(#mask-2)" fill="#77216F" xlink:href="#path-1"></use>
+          </g>
+        </svg>
+        <h3 class="p-card__title">Light aubergine</h3>
+        <h4>Screen</h4>
+        <p class="p-card__content">HEX #77216F</p>
+        <h4>Print</h4>
+        <p class="p-card__content">
+          C60 M100 Y15 K5
+          <br />
+          Pantone 512
+        </p>
+      </div>
+      <div class="col-4 p-card">
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <svg width="275px"
+             height="128px"
+             viewBox="0 0 275 128"
+             version="1.1"
+             xmlns="http://www.w3.org/2000/svg"
+             xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+          <rect id="path-1" x="0" y="0" width="275" height="128"></rect>
+          </defs>
+          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <use id="Rectangle" mask="url(#mask-2)" fill="#5E2750" xlink:href="#path-1"></use>
+          </g>
+        </svg>
+        <h3 class="p-card__title">Mid aubergine</h3>
+        <h4>Screen</h4>
+        <p class="p-card__content">HEX #5E2750</p>
+        <h4>Print</h4>
+        <p class="p-card__content">
+          C70 M100 Y50 K20
+          <br />
+          Pantone 511
+        </p>
+      </div>
+      <div class="col-4 p-card">
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <svg width="275px"
+             height="128px"
+             viewBox="0 0 275 128"
+             version="1.1"
+             xmlns="http://www.w3.org/2000/svg"
+             xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+          <rect id="path-1" x="0" y="0" width="275" height="128"></rect>
+          </defs>
+          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <use id="Rectangle" mask="url(#mask-2)" fill="#2C001E" xlink:href="#path-1"></use>
+          </g>
+        </svg>
+        <h3 class="p-card__title">Dark aubergine</h3>
+        <h4>Screen</h4>
+        <p class="p-card__content">HEX #2C001E</p>
+        <h4>Print</h4>
+        <p class="p-card__content">
+          C66 M98 Y21 K85
+          <br />
+          Pantone 7449
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip is-bordered">
+    <div class="row">
+      <div class="col-8">
+        <h2>Neutral colours</h2>
+        <h3>Warm grey</h3>
+        <p>
+          For balance. The addition of warm grey softens the combination of orange and aubergine and provides a bridge between the two.
+        </p>
+        <p>
+          Warm grey can be used for; backgrounds, graphics, dot patterns, charts and diagrams. It can also be used for large size text.
+        </p>
+        <h3>Cool grey</h3>
+        <p>
+          For typography, particularly body copy. Black can be quite harsh in combination with aubergine, but grey delivers more balance while still being legible.
+        </p>
+        <p>Cool grey can also be used within charts and diagrams.</p>
+      </div>
+    </div>
+
+    <div class="row u-equal-height">
+      <div class="col-4 p-card">
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <svg width="275px"
+             height="128px"
+             viewBox="0 0 275 128"
+             version="1.1"
+             xmlns="http://www.w3.org/2000/svg"
+             xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+          <rect id="path-1" x="0" y="0" width="275" height="128"></rect>
+          </defs>
+          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <use id="Rectangle" mask="url(#mask-2)" fill="#AEA79F" xlink:href="#path-1"></use>
+          </g>
+        </svg>
+        <h3 class="p-card__title">Warm grey</h3>
+        <h4>Screen</h4>
+        <p class="p-card__content">HEX #AEA79F</p>
+        <h4>Print</h4>
+        <p class="p-card__content">
+          C0 M5 Y10 K29
+          <br />
+          Pantone Warm Grey 5
+        </p>
+      </div>
+      <div class="col-4 p-card">
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <svg width="275px"
+             height="128px"
+             viewBox="0 0 275 128"
+             version="1.1"
+             xmlns="http://www.w3.org/2000/svg"
+             xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+          <rect id="path-1" x="0" y="0" width="275" height="128"></rect>
+          </defs>
+          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <use id="Rectangle" mask="url(#mask-2)" fill="#333333" xlink:href="#path-1"></use>
+          </g>
+        </svg>
+        <h3 class="p-card__title">Cool grey</h3>
+        <h4>Screen</h4>
+        <p class="p-card__content">HEX #333333</p>
+        <h4>Print</h4>
+        <p class="p-card__content">
+          C44 M34 Y22 K78
+          <br />
+          Pantone Cool Grey 11
+        </p>
+      </div>
+      <div class="col-4 p-card">
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <svg width="275px"
+             height="128px"
+             viewBox="0 0 275 128"
+             version="1.1"
+             xmlns="http://www.w3.org/2000/svg"
+             xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+          <rect id="path-1" x="0" y="0" width="275" height="128"></rect>
+          </defs>
+          <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <use id="Rectangle" mask="url(#mask-2)" fill="#111111" xlink:href="#path-1"></use>
+          </g>
+        </svg>
+        <h3 class="p-card__title">Text grey</h3>
+        <h4>Screen</h4>
+        <p class="p-card__content">HEX #111111</p>
+        <h4>Print</h4>
+        <p class="p-card__content">
+          C0 M0 Y0 K93
+          <br />
+          Pantone Black 2 2X
+        </p>
+        <p class="p-card__content">Text grey is used for small size headings, sub-headings and body copy text only.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip is-bordered">
+    <div class="row">
+      <div class="col-8">
+        <h2>Canonical core colours</h2>
+        <p>
+          The Canonical colour palette has been created to reflect the spirit of our brand. Aubergine for a smart, focussed feel. White for a clean, fresh and light feel.
+        </p>
+
+        <div class="row u-equal-height">
+          <div class="col-4 p-card">
+            <img src="https://assets.ubuntu.com/v1/b8514097-canonical-aubergine.png"
+                 alt="Canonical aubergine"
+                 title="Canonical aubergine"
+                 width="300"
+                 height="140"
+                 class="alignleft size-full1" />
+            <h3 class="p-card__title">Canonical aubergine</h3>
+            <h4>Screen</h4>
+            <p class="p-card__content">HEX #772953</p>
+            <h4>Print</h4>
+            <p class="p-card__content">
+              C26 M99 Y12 K52
+              <br />
+              Pantone 683
+            </p>
+          </div>
+          <div class="col-4 p-card">
+            <img src="https://assets.ubuntu.com/v1/54f4e9da-white.png"
+                 alt="White"
+                 title="White"
+                 width="300"
+                 height="140" />
+            <h3 class="p-card__title">White</h3>
+            <h4>Screen</h4>
+            <p class="p-card__content">HEX #FFFFFF</p>
+            <h4>Print</h4>
+            <p class="p-card__content">C0 M0 Y0 K0</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip">
+    <div class="row">
+      <div class="col-6">
+        <h2>Tints</h2>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-6">
+        <ul class="p-list" style="background-color:#E95420;">
+          <li style="color: #ffffff; background-color:#E95420;">
+            <h4>Ubuntu Orange</h4>
+            <p>
+              <span class="tint-percentage">100%</span><span style="float: right; margin-top:0;">#E95420</span>
+            </p>
+          </li>
+          <li style="color: #ffffff; background-color:#EB6536;">
+            <span class="tint-percentage">90%</span><span style="float: right; margin-top:0;">#EB6536</span>
+          </li>
+          <li style="color: #ffffff; background-color:#ED764D;">
+            <span class="tint-percentage">80%</span><span style="float: right; margin-top:0;">#ED764D</span>
+          </li>
+          <li style="color: #ffffff; background-color:#F08763;">
+            <span class="tint-percentage">70%</span><span style="float: right; margin-top:0;">#F08763</span>
+          </li>
+          <li style="color: #ffffff; background-color:#F29879;">
+            <span class="tint-percentage">60%</span><span style="float: right; margin-top:0;">#F29879</span>
+          </li>
+          <li style="background-color:#F4AA90;">
+            <span class="tint-percentage">50%</span><span style="float: right; margin-top:0;">#F4AA90</span>
+          </li>
+          <li style="background-color:#F5B29B;">
+            <span class="tint-percentage">45%</span><span style="float: right; margin-top:0;">#F5B29B</span>
+          </li>
+          <li style="background-color:#F6BBA6;">
+            <span class="tint-percentage">40%</span><span style="float: right; margin-top:0;">#F6BBA6</span>
+          </li>
+          <li style="background-color:#F7C3B1;">
+            <span class="tint-percentage">35%</span><span style="float: right; margin-top:0;">#F7C3B1</span>
+          </li>
+          <li style="background-color:#F8CCBC;">
+            <span class="tint-percentage">30%</span><span style="float: right; margin-top:0;">#F8CCBC</span>
+          </li>
+          <li style="background-color:#FAD4C7;">
+            <span class="tint-percentage">25%</span><span style="float: right; margin-top:0;">#FAD4C7</span>
+          </li>
+          <li style="background-color:#FBDDD2;">
+            <span class="tint-percentage">20%</span><span style="float: right; margin-top:0;">#FBDDD2</span>
+          </li>
+          <li style="background-color:#FCE5DE;">
+            <span class="tint-percentage">15%</span><span style="float: right; margin-top:0;">#FCE5DE</span>
+          </li>
+          <li style="background-color:#FDEEE9;">
+            <span class="tint-percentage">10%</span><span style="float: right; margin-top:0;">#FDEEE9</span>
+          </li>
+        </ul>
+      </div>
+      <div class="col-6">
+        <ul class="p-list" style="background-color:#772953;">
+          <li style="color: #ffffff; background-color:#772953;">
+            <h4>Canonical Aubergine</h4>
+            <p>
+              <span class="tint-percentage">100%</span><span style="float: right; margin-top:0;">#772953</span>
+            </p>
+          </li>
+          <li style="color: #ffffff; background-color:#843E64;">
+            <span class="tint-percentage">90%</span><span style="float: right; margin-top:0;">#843E64</span>
+          </li>
+          <li style="color: #ffffff; background-color:#925375;">
+            <span class="tint-percentage">80%</span><span style="float: right; margin-top:0;">#925375</span>
+          </li>
+          <li style="color: #ffffff; background-color:#9F6986;">
+            <span class="tint-percentage">70%</span><span style="float: right; margin-top:0;">#9F6986</span>
+          </li>
+          <li style="color: #ffffff; background-color:#AD7E97;">
+            <span class="tint-percentage">60%</span><span style="float: right; margin-top:0;">#AD7E97</span>
+          </li>
+          <li style="background-color:#BB94A9;">
+            <span class="tint-percentage">50%</span><span style="float: right; margin-top:0;">#BB94A9</span>
+          </li>
+          <li style="background-color:#C19EB1;">
+            <span class="tint-percentage">45%</span><span style="float: right; margin-top:0;">#C19EB1</span>
+          </li>
+          <li style="background-color:#C8A9BA;">
+            <span class="tint-percentage">40%</span><span style="float: right; margin-top:0;">#C8A9BA</span>
+          </li>
+          <li style="background-color:#CFB4C2;">
+            <span class="tint-percentage">35%</span><span style="float: right; margin-top:0;">#CFB4C2</span>
+          </li>
+          <li style="background-color:#D6BECB;">
+            <span class="tint-percentage">30%</span><span style="float: right; margin-top:0;">#D6BECB</span>
+          </li>
+          <li style="background-color:#DDC9D4;">
+            <span class="tint-percentage">25%</span><span style="float: right; margin-top:0;">#DDC9D4</span>
+          </li>
+          <li style="background-color:#E3D4DC;">
+            <span class="tint-percentage">20%</span><span style="float: right; margin-top:0;">#E3D4DC</span>
+          </li>
+          <li style="background-color:#EADEE5;">
+            <span class="tint-percentage">15%</span><span style="float: right; margin-top:0;">#EADEE5</span>
+          </li>
+          <li style="background-color:#F1E9ED;">
+            <span class="tint-percentage">10%</span><span style="float: right; margin-top:0;">#F1E9ED</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-6">
+        <ul class="p-list" style="background-color:#77216F;">
+          <li style="color: #ffffff; background-color:#77216F;">
+            <h4>Light Aubergine</h4>
+            <p>
+              <span class="tint-percentage">100%</span><span style="float: right; margin-top:0;">#77216F</span>
+            </p>
+          </li>
+          <li style="color: #ffffff; background-color:#84377D;">
+            <span class="tint-percentage">90%</span><span style="float: right; margin-top:0;">#84377D</span>
+          </li>
+          <li style="color: #ffffff; background-color:#924D8B;">
+            <span class="tint-percentage">80%</span><span style="float: right; margin-top:0;">#924D8B</span>
+          </li>
+          <li style="color: #ffffff; background-color:#9F639A;">
+            <span class="tint-percentage">70%</span><span style="float: right; margin-top:0;">#9F639A</span>
+          </li>
+          <li style="color: #ffffff; background-color:#AD79A8;">
+            <span class="tint-percentage">60%</span><span style="float: right; margin-top:0;">#AD79A8</span>
+          </li>
+          <li style="background-color:#BB90B7;">
+            <span class="tint-percentage">50%</span><span style="float: right; margin-top:0;">#BB90B7</span>
+          </li>
+          <li style="background-color:#C19BBE;">
+            <span class="tint-percentage">45%</span><span style="float: right; margin-top:0;">#C19BBE</span>
+          </li>
+          <li style="background-color:#C8A6C5;">
+            <span class="tint-percentage">40%</span><span style="float: right; margin-top:0;">#C8A6C5</span>
+          </li>
+          <li style="background-color:#CFB1CC;">
+            <span class="tint-percentage">35%</span><span style="float: right; margin-top:0;">#CFB1CC</span>
+          </li>
+          <li style="background-color:#D6BCD3;">
+            <span class="tint-percentage">30%</span><span style="float: right; margin-top:0;">#D6BCD3</span>
+          </li>
+          <li style="background-color:#DDC7DB;">
+            <span class="tint-percentage">25%</span><span style="float: right; margin-top:0;">#DDC7DB</span>
+          </li>
+          <li style="background-color:#E3D2E2;">
+            <span class="tint-percentage">20%</span><span style="float: right; margin-top:0;">#E3D2E2</span>
+          </li>
+          <li style="background-color:#EADDE9;">
+            <span class="tint-percentage">15%</span><span style="float: right; margin-top:0;">#EADDE9</span>
+          </li>
+          <li style="background-color:#F1E8F0;">
+            <span class="tint-percentage">10%</span><span style="float: right; margin-top:0;">#F1E8F0</span>
+          </li>
+        </ul>
+      </div>
+      <div class="col-6">
+        <ul class="p-list" style="background-color:#5E2750;">
+          <li style="color: #ffffff; background-color:#5E2750;">
+            <h4>Mid Aubergine</h4>
+            <p>
+              <span class="tint-percentage">100%</span><span style="float: right; margin-top:0;">#5E2750</span>
+            </p>
+          </li>
+          <li style="color: #ffffff; background-color:#6E3C61;">
+            <span class="tint-percentage">90%</span><span style="float: right; margin-top:0;">#6E3C61</span>
+          </li>
+          <li style="color: #ffffff; background-color:#7E5273;">
+            <span class="tint-percentage">80%</span><span style="float: right; margin-top:0;">#7E5273</span>
+          </li>
+          <li style="color: #ffffff; background-color:#8E6784;">
+            <span class="tint-percentage">70%</span><span style="float: right; margin-top:0;">#8E6784</span>
+          </li>
+          <li style="color: #ffffff; background-color:#9E7D96;">
+            <span class="tint-percentage">60%</span><span style="float: right; margin-top:0;">#9E7D96</span>
+          </li>
+          <li style="background-color:#AE93A7;">
+            <span class="tint-percentage">50%</span><span style="float: right; margin-top:0;">#AE93A7</span>
+          </li>
+          <li style="background-color:#B69DB0;">
+            <span class="tint-percentage">45%</span><span style="float: right; margin-top:0;">#B69DB0</span>
+          </li>
+          <li style="background-color:#BEA8B9;">
+            <span class="tint-percentage">40%</span><span style="float: right; margin-top:0;">#BEA8B9</span>
+          </li>
+          <li style="background-color:#C6B3C1;">
+            <span class="tint-percentage">35%</span><span style="float: right; margin-top:0;">#C6B3C1</span>
+          </li>
+          <li style="background-color:#CEBECA;">
+            <span class="tint-percentage">30%</span><span style="float: right; margin-top:0;">#CEBECA</span>
+          </li>
+          <li style="background-color:#D6C9D3;">
+            <span class="tint-percentage">25%</span><span style="float: right; margin-top:0;">#D6C9D3</span>
+          </li>
+          <li style="background-color:#DED3DC;">
+            <span class="tint-percentage">20%</span><span style="float: right; margin-top:0;">#DED3DC</span>
+          </li>
+          <li style="background-color:#E6DEE4;">
+            <span class="tint-percentage">15%</span><span style="float: right; margin-top:0;">#E6DEE4</span>
+          </li>
+          <li style="background-color:#EEE9ED;">
+            <span class="tint-percentage">10%</span><span style="float: right; margin-top:0;">#EEE9ED</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-6">
+        <ul class="p-list" style="background-color:#2C001E;">
+          <li style="color: #ffffff; background-color:#2C001E;">
+            <h4>Dark Aubergine</h4>
+            <p>
+              <span class="tint-percentage">100%</span><span style="float: right; margin-top:0;">#2C001E</span>
+            </p>
+          </li>
+          <li style="color: #ffffff; background-color:#411934;">
+            <span class="tint-percentage">90%</span><span style="float: right; margin-top:0;">#411934</span>
+          </li>
+          <li style="color: #ffffff; background-color:#56334B;">
+            <span class="tint-percentage">80%</span><span style="float: right; margin-top:0;">#56334B</span>
+          </li>
+          <li style="color: #ffffff; background-color:#6B4C61;">
+            <span class="tint-percentage">70%</span><span style="float: right; margin-top:0;">#6B4C61</span>
+          </li>
+          <li style="color: #ffffff; background-color:#806678;">
+            <span class="tint-percentage">60%</span><span style="float: right; margin-top:0;">#806678</span>
+          </li>
+          <li style="background-color:#957F8E;">
+            <span class="tint-percentage">50%</span><span style="float: right; margin-top:0;">#957F8E</span>
+          </li>
+          <li style="background-color:#A08C99;">
+            <span class="tint-percentage">45%</span><span style="float: right; margin-top:0;">#A08C99</span>
+          </li>
+          <li style="background-color:#AA99A5;">
+            <span class="tint-percentage">40%</span><span style="float: right; margin-top:0;">#AA99A5</span>
+          </li>
+          <li style="background-color:#B5A5B0;">
+            <span class="tint-percentage">35%</span><span style="float: right; margin-top:0;">#B5A5B0</span>
+          </li>
+          <li style="background-color:#BFB2BB;">
+            <span class="tint-percentage">30%</span><span style="float: right; margin-top:0;">#BFB2BB</span>
+          </li>
+          <li style="background-color:#CABFC6;">
+            <span class="tint-percentage">25%</span><span style="float: right; margin-top:0;">#CABFC6</span>
+          </li>
+          <li style="background-color:#D4CCD2;">
+            <span class="tint-percentage">20%</span><span style="float: right; margin-top:0;">#D4CCD2</span>
+          </li>
+          <li style="background-color:#DFD8DD;">
+            <span class="tint-percentage">15%</span><span style="float: right; margin-top:0;">#DFD8DD</span>
+          </li>
+          <li style="background-color:#E9E5E8;">
+            <span class="tint-percentage">10%</span><span style="float: right; margin-top:0;">#E9E5E8</span>
+          </li>
+        </ul>
+      </div>
+      <div class="col-6">
+        <ul class="p-list" style="background-color:#AEA79F;">
+          <li style="background-color:#AEA79F;">
+            <h4>Warm Grey</h4>
+            <p>
+              <span class="tint-percentage">100%</span><span style="float: right; margin-top:0;">#AEA79F</span>
+            </p>
+          </li>
+          <li style="background-color:#B6AFA8;">
+            <span class="tint-percentage">90%</span><span style="float: right; margin-top:0;">#B6AFA8</span>
+          </li>
+          <li style="background-color:#BEB8B2;">
+            <span class="tint-percentage">80%</span><span style="float: right; margin-top:0;">#BEB8B2</span>
+          </li>
+          <li style="background-color:#C6C1BB;">
+            <span class="tint-percentage">70%</span><span style="float: right; margin-top:0;">#C6C1BB</span>
+          </li>
+          <li style="background-color:#CECAC5;">
+            <span class="tint-percentage">60%</span><span style="float: right; margin-top:0;">#CECAC5</span>
+          </li>
+          <li style="background-color:#D6D3CF;">
+            <span class="tint-percentage">50%</span><span style="float: right; margin-top:0;">#D6D3CF</span>
+          </li>
+          <li style="background-color:#DAD7D3;">
+            <span class="tint-percentage">45%</span><span style="float: right; margin-top:0;">#DAD7D3</span>
+          </li>
+          <li style="background-color:#DEDBD8;">
+            <span class="tint-percentage">40%</span><span style="float: right; margin-top:0;">#DEDBD8</span>
+          </li>
+          <li style="background-color:#E2E0DD;">
+            <span class="tint-percentage">35%</span><span style="float: right; margin-top:0;">#E2E0DD</span>
+          </li>
+          <li style="background-color:#E6E4E2;">
+            <span class="tint-percentage">30%</span><span style="float: right; margin-top:0;">#E6E4E2</span>
+          </li>
+          <li style="background-color:#EAE9E7;">
+            <span class="tint-percentage">25%</span><span style="float: right; margin-top:0;">#EAE9E7</span>
+          </li>
+          <li style="background-color:#EEEDEB;">
+            <span class="tint-percentage">20%</span><span style="float: right; margin-top:0;">#EEEDEB</span>
+          </li>
+          <li style="background-color:#F2F1F0;">
+            <span class="tint-percentage">15%</span><span style="float: right; margin-top:0;">#F2F1F0</span>
+          </li>
+          <li style="background-color:#F6F6F5;">
+            <span class="tint-percentage">10%</span><span style="float: right; margin-top:0;">#F6F6F5</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-8">
+        <p>
+          Tints of the above palette colours can be used as background colours and in charts and diagrams when a clear visual hierarchy of information is needed.
+        </p>
+        <h3>Tint percentages</h3>
+        <p>Use only the percentages shown on this page. Never use a tint less than 10%.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip">
+    <div class="row">
+      <div class="col-8">
+        <h2>The amount of colour we use</h2>
+        <p>
+          <img src="https://assets.ubuntu.com/v1/13e0eef4-ubuntu-colour-wheel-voice.png"
+               alt="Colour pie chart"
+               title="Colour pie chart"
+               width="540"
+               height="264"
+               srcset="https://assets.ubuntu.com/v1/13e0eef4-ubuntu-colour-wheel-voice.png 540w,
+                       https://assets.ubuntu.com/v1/0a0191b4-ubuntu-colour-wheel-voice-300x146.png 300w"
+               sizes="(max-width: 540px) 100vw,
+                      540px" />
+        </p>
+        <p>
+          Our colour palette consists of orange, aubergine, white and warm grey. The amount of colour we use for community and Canonical collateral varies according to the emphasis of the content.
+        </p>
+        <p>
+          At one end of the scale, where the work is dominated by the community, the emphasis is on a fresh palette, the use of white and orange, and warm grey for balance. Aubergine is used only as a highlight.
+        </p>
+        <p>
+          At the other end of the scale, where the work is more focused on Canonical, the palette is more refined and grounded, with much more emphasis on aubergine as the core colour. Orange is only used as a highlight and we use white and warm grey to complement
+          the orange and aubergine.
+        </p>
+
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/templates/brand/colour-palette.html
+++ b/templates/brand/colour-palette.html
@@ -354,7 +354,7 @@
     </div>
   </div>
 
-  <div class="p-strip">
+  <div class="p-strip is-bordered">
     <div class="row">
       <div class="col-6">
         <h2>Tints</h2>

--- a/templates/brand/index.html
+++ b/templates/brand/index.html
@@ -78,13 +78,17 @@
       <div class="col-6 col-medium-2">
         <h2>Brand assets</h2>
       </div>
-      <div class="col-3 col-medium-2 p-card p-media-container">
+      <div class="col-3 col-medium-2 p-card p-media-container is-light">
         <div class="u-vertically-center u-align--center">
-          <img style="min-height: 195px"
-               class="p-card__image"
-               src="https://assets.ubuntu.com/v1/ff6a9a38-ubuntu-logo-2022.svg"
-               alt="Ubuntu logo"
-               width="160" />
+          {{ image(url="https://assets.ubuntu.com/v1/4dd49dac-logo.png",
+            alt="",
+            width="478",
+            height="390",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-card_image"}
+            ) | safe
+          }}
         </div>
         <div class="p-card__content">
           <h3>
@@ -98,9 +102,15 @@
 
       <div class="col-3 col-medium-2 p-card p-media-container is-light">
         <a href="/brand/colour-palette">
-          <img class="p-card__image"
-               src="https://assets.ubuntu.com/v1/ebb3f015-colour-palette.svg"
-               alt="" />
+          {{ image(url="https://assets.ubuntu.com/v1/27e4ad2f-colors.png",
+            alt="",
+            width="478",
+            height="390",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-card_image"}
+            ) | safe
+          }}
         </a>
         <div class="p-card__content">
           <h3>

--- a/templates/brand/index.html
+++ b/templates/brand/index.html
@@ -12,6 +12,9 @@
   https://docs.google.com/document/d/1nyNLG5IfJHRpGGMJzJIkm3TJSXTvd4vOdMhu2M9Lfxo/edit?tab=t.0
 {% endblock meta_copydoc %}
 
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
 
@@ -93,7 +96,7 @@
         </div>
       </div>
 
-      <div class="col-3 col-medium-2 p-card p-media-container">
+      <div class="col-3 col-medium-2 p-card p-media-container is-light">
         <a href="/brand/colour-palette">
           <img class="p-card__image"
                src="https://assets.ubuntu.com/v1/ebb3f015-colour-palette.svg"

--- a/templates/brand/index.html
+++ b/templates/brand/index.html
@@ -9,110 +9,105 @@
 {% endblock meta_description %}
 
 {% block meta_copydoc %}
-  <!-- to be added -->
+  https://docs.google.com/document/d/1nyNLG5IfJHRpGGMJzJIkm3TJSXTvd4vOdMhu2M9Lfxo/edit?tab=t.0
 {% endblock meta_copydoc %}
 
+
 {% block content %}
-  <div class="wrapper u-no-margin-top">
-    <main id="main-content" class="inner-wrapper">
-      <div class="p-suru--25-75">
-        <div class="p-section">
 
-          <div class="row--50-50">
-            <div class="col">
-              <h1>Canonical and Ubuntu</h1>
-              <p class="p-heading--2">Our brand values</p>
-            </div>
-            <div class="col">
-              <p>
-                We believe everyone has the right to a great computing experience — and we also believe it should be free. Ubuntu is the result of a growing community, working together to provide just that. As such, the Ubuntu brand embodies four values:
-              </p>
-            </div>
-          </div>
+  <section class="p-suru--25-75">
+    <div class="p-section">
+      <div class="row--50-50">
+        <div class="col">
+          <h1>Canonical and Ubuntu</h1>
+          <h2>Our brand values</h2>
         </div>
+        <div class="col">
+          <p>
+            We believe everyone has the right to a great computing experience &mdash; and we also believe it should be free. Ubuntu is the result of a growing community, working together to provide just that. As such, the Ubuntu brand embodies four values:
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <hr class="p-rule--muted" />
+      <div class="col-3 col-medium-3">
+        <h3>Freedom</h3>
+        <p>Ubuntu celebrates freedom. Freedom to choose, to change, to participate.</p>
+      </div>
+      <div class="col-3 col-medium-3">
+        <h3>Reliable</h3>
+        <p>You can depend on Ubuntu. Like the people who make it, it is trustworthy and keeps its promises.</p>
+      </div>
+      <div class="col-3 col-medium-3">
+        <h3>Precise</h3>
+        <p>
+          Ubuntu is crisp and clean in engineering and attitude. There is beauty in the precision of the process and product.
+        </p>
+      </div>
+      <div class="col-3 col-medium-3">
+        <h3>Collaborative</h3>
+        <p>Working together is at the heart of Ubuntu. It is the essence of 'humanity towards others'.</p>
+      </div>
+    </div>
+  </section>
 
-        <div class="row">
-          <hr class="p-rule" />
-          <div class="col-3 col-medium-3">
-            <h3>Freedom</h3>
-            <p>Ubuntu celebrates freedom. Freedom to choose, to change, to participate.</p>
-          </div>
-          <div class="col-3 col-medium-3">
-            <h3>Reliable</h3>
-            <p>You can depend on Ubuntu. Like the people who make it, it is trustworthy and keeps its promises.</p>
-          </div>
-          <div class="col-3 col-medium-3">
-            <h3>Precise</h3>
-            <p>
-              Ubuntu is crisp and clean in engineering and attitude. There is beauty in the precision of the process and product.
-            </p>
-          </div>
-          <div class="col-3 col-medium-3">
-            <h3>Collaborative</h3>
-            <p>Working together is at the heart of Ubuntu. It is the essence of ’humanity towards others‘.</p>
-          </div>
+  <section class="p-section is-light">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Our brand guidelines</h2>
+      </div>
+      <div class="col">
+        <p>
+          Our values should be evident wherever Ubuntu is encountered, whether online or via traditional marketing material. If we follow these guidelines consistently, the brand will grow strong enough to attract people, encouraging them to look even more positively on the product itself.
+        </p>
+        <p>
+          These guidelines provide everything you need to create professional communication materials that will build the Ubuntu brand. To help ensure the continued success of Ubuntu, please use them.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-6 col-medium-2">
+        <h2>Brand assets</h2>
+      </div>
+      <div class="col-3 col-medium-2 p-card p-media-container">
+        <div class="u-vertically-center u-align--center">
+          <img style="min-height: 195px"
+               class="p-card__image"
+               src="https://assets.ubuntu.com/v1/ff6a9a38-ubuntu-logo-2022.svg"
+               alt="Ubuntu logo"
+               width="160" />
+        </div>
+        <div class="p-card__content">
+          <h3>
+            <a href="/resources">Logos</a>
+          </h3>
+          <p>
+            The logo is the most recognizable feature of any brand identity. The Ubuntu logo is striking and clear, and it represents the brand’s core values.
+          </p>
         </div>
       </div>
 
-      <section class="p-section">
-        <div class="row--50-50-on-large row--25-75-on-medium">
-          <hr class="p-rule" />
-          <div class="col">
-            <h2>Our brand guidelines</h2>
-          </div>
-          <div class="col">
-            <p>
-              Our values should be evident wherever Ubuntu is encountered, whether online or via traditional marketing material. If we follow these guidelines consistently, the brand will grow strong enough to attract people, encouraging them to look even more positively on the product itself.
-            </p>
-            <p>
-              These guidelines provide everything you need to create professional communication materials that will build the Ubuntu brand. To help ensure the continued success of Ubuntu, please use them.
-            </p>
-          </div>
+      <div class="col-3 col-medium-2 p-card p-media-container">
+        <a href="/brand/colour-palette">
+          <img class="p-card__image"
+               src="https://assets.ubuntu.com/v1/ebb3f015-colour-palette.svg"
+               alt="" />
+        </a>
+        <div class="p-card__content">
+          <h3>
+            <a href="/brand/colour-palette">Color palette</a>
+          </h3>
+          <p class="p-card__content">
+            The vibrant Ubuntu color palette was created and evolved to ensure that designs convey the correct meaning, while aligning to the brand colors.
+          </p>
         </div>
-      </section>
-
-      <section class="p-section--deep">
-        <div class="row u-equal-height">
-          <hr class="p-rule" />
-          <div class="col-6 col-medium-2">
-            <h2>Brand assets</h2>
-          </div>
-          <div class="col-3 col-medium-2 p-card p-media-container">
-            <div class="u-vertically-center u-align--center">
-              <img style="min-height: 195px"
-                   class="p-card__image"
-                   src="https://assets.ubuntu.com/v1/ff6a9a38-ubuntu-logo-2022.svg"
-                   alt="Ubuntu logo"
-                   width="160" />
-            </div>
-            <div class="p-card__content">
-              <h3>
-                <a href="./brand_resources.html">Logos</a>
-              </h3>
-              <p>
-                The logo is the most recognisable feature of any brand identity. The Ubuntu logo is striking and clear, and it represents the brand’s core values.
-              </p>
-            </div>
-          </div>
-
-          <div class="col-3 col-medium-2 p-card p-media-container">
-            <a href="/brand/colour-palette">
-              <img class="p-card__image"
-                   src="https://assets.ubuntu.com/v1/ebb3f015-colour-palette.svg"
-                   alt="" />
-            </a>
-            <div class="p-card__content">
-              <h3>
-                <a href="/brand/colour-palette">Colour palette</a>
-              </h3>
-              <p class="p-card__content">
-                The vibrant Ubuntu colour palette was created and evolved to ensure that designs convey the correct meaning, while aligning to the brand colours.
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-    </main>
-  </div>
+      </div>
+    </div>
+  </section>
 {% endblock content %}

--- a/templates/brand/index.html
+++ b/templates/brand/index.html
@@ -80,14 +80,13 @@
       </div>
       <div class="col-3 col-medium-2 p-card p-media-container is-light">
         <div class="u-vertically-center u-align--center">
-          {{ image(url="https://assets.ubuntu.com/v1/4dd49dac-logo.png",
-            alt="",
-            width="478",
-            height="390",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-card_image"}
-            ) | safe
+          {{ image(url="https://assets.ubuntu.com/v1/272486ef-logos.png",
+                    alt="",
+                    width="717",
+                    height="585",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-card_image"}) | safe
           }}
         </div>
         <div class="p-card__content">
@@ -102,14 +101,13 @@
 
       <div class="col-3 col-medium-2 p-card p-media-container is-light">
         <a href="/brand/colour-palette">
-          {{ image(url="https://assets.ubuntu.com/v1/27e4ad2f-colors.png",
-            alt="",
-            width="478",
-            height="390",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-card_image"}
-            ) | safe
+          {{ image(url="https://assets.ubuntu.com/v1/9fc3dc26-color palette.png",
+                    alt="",
+                    width="717",
+                    height="585",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-card_image"}) | safe
           }}
         </a>
         <div class="p-card__content">

--- a/templates/brand/index.html
+++ b/templates/brand/index.html
@@ -33,7 +33,7 @@
       </div>
     </div>
     <div class="row">
-      <hr class="p-rule--muted" />
+      <hr class="p-rule" />
       <div class="col-3 col-medium-3">
         <h3>Freedom</h3>
         <p>Ubuntu celebrates freedom. Freedom to choose, to change, to participate.</p>


### PR DESCRIPTION
## Done

- Aligned /brand landing page with live site
- Fixed minor bugs and applied minor design updates 
- /brand/colour-palette is a direct copy/paste of the [live site](https://github.com/canonical/design.ubuntu.com/blob/main/templates/brand/colour-palette/index.html) as it was missing from this repo

## QA

- View the site locally in your web browser at: https://canonical-design-33.demos.haus/brand and https://canonical-design-33.demos.haus/brand/colour-palette
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check against live site

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-18643
