### PR TITLE
Fix missing cover image aspect ratios

### DIFF
--- a/templates/design-systems/index.html
+++ b/templates/design-systems/index.html
@@ -197,7 +197,7 @@
       </div>
     </div>
     <div class="u-fixed-width">
-      <div class="p-image-container is-cover">
+      <div class="p-image-container--cinematic is-cover">
         {{ image(url="https://assets.ubuntu.com/v1/7fcb1203-design-systems-hierarchy.png",
                 alt="",
                 width="3696",

--- a/templates/index.html
+++ b/templates/index.html
@@ -95,7 +95,7 @@
             <div class="col-3 col-medium-2">
               <a href="/design-practice">
                 <h3 class="p-heading--5">Design practice</h3>
-                <div class="p-image-container is-cover">
+                <div class="p-image-container--16-9 is-cover">
                   {{ image(url="https://assets.ubuntu.com/v1/c2a9b8f8-design-practice.png",
                                     alt="",
                                     width="852",

--- a/templates/open-design/index.html
+++ b/templates/open-design/index.html
@@ -32,7 +32,7 @@
       </p>
     {%- endif -%}
     {%- if slot == 'image' -%}
-      <div class="p-image-container is-cover is-highlighted">
+      <div class="p-image-container--cinematic is-cover is-highlighted">
         {{ image(url="https://assets.ubuntu.com/v1/4206dcc7-sauce_hero.svg",
                 alt="",
                 width="2400",


### PR DESCRIPTION
## Done

Similar to https://github.com/canonical/ubuntu.com/pull/15431, some cases were found of cover images without their required aspect ratio classes. This would cause images to not render in Vanilla >= 4.26.1.

This project hasn't been upgraded past 4.26.1, so there will be no visual changes - this will just prevent any issues after upgrading.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8052/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to these pages and verify their cover images are still rendered as expected:
  - [design-systems](https://canonical-design-57.demos.haus/design-systems)
  - [home](https://canonical-design-57.demos.haus)
  - [open-design](https://canonical-design-57.demos.haus/open-design)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
