### PR TITLE
[DE-852] Move and tweak accessibility page

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,0 +1,2 @@
+/accessibility: /design-practice/accessibility
+/brand/accessibility: /design-practice/accessibility

--- a/templates/_layouts/_navigation.html
+++ b/templates/_layouts/_navigation.html
@@ -39,6 +39,10 @@
               <a href="/design-practice/user-research"
                  class="p-navigation__dropdown-item">User research</a>
             </li>
+            <li>
+              <a href="/design-practice/accessibility"
+                 class="p-navigation__dropdown-item">Accessibility</a>
+            </li>
           </ul>
         </li>
         <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle"
@@ -59,9 +63,6 @@
             </li>
             <li>
               <a href="/brand/font" class="p-navigation__dropdown-item">Font</a>
-            </li>
-            <li>
-              <a href="/brand/accessibility" class="p-navigation__dropdown-item">Accessibility</a>
             </li>
             <li>
               <a href="/brand/resources" class="p-navigation__dropdown-item">Resources</a>

--- a/templates/design-practice/accessibility.html
+++ b/templates/design-practice/accessibility.html
@@ -75,7 +75,7 @@
     <div class="u-fixed-width">
       <ul class="p-list is-split">
         <li class="p-list__item is-ticked">Make sure there is enough contrast between text and its background color</li>
-        <li class="p-list__item is-ticked">Don't indicate important information using colour alone</li>
+        <li class="p-list__item is-ticked">Don't indicate important information using color alone</li>
         <li class="p-list__item is-ticked">Design focus states to help users navigate and understand where they are</li>
         <li class="p-list__item is-ticked">Links should be visually identifiable and have clearly distinct states</li>
         <li class="p-list__item is-ticked">Be as consistent and clear as possible in layout and copy</li>
@@ -109,45 +109,43 @@
 
   <div class="p-section">
     <div class="row--50-50">
-      <div class="row">
-        <hr class="p-rule" />
-        <div class="col-6">
-          <h2>Key WCAG documents</h2>
-          <p>
-            The volume of information on the WCAG website can be disorienting.
-            <br />
-            We keep the following links handy for quick reference:
-          </p>
-        </div>
-
-        <div class="col-6">
-          <ul class="p-list--divided u-no-margin--bottom">
-            <li class="p-list__item">
-              <h3 class="p-heading--5 u-no-margin--bottom">
-                <a href="https://www.w3.org/TR/WCAG22/">WCAG 2.2</a>
-              </h3>
-              <p>The W3C standard, includes principles, guidelines and success criteria</p>
-            </li>
-            <li class="p-list__item">
-              <h3 class="p-heading--5 u-no-margin--bottom">
-                <a href="https://www.w3.org/WAI/WCAG22/Understanding/">Understanding WCAG 2.2</a>
-              </h3>
-              <p>Detailed reference, includes intent, benefits to people with disabilities, examples, resources and techniques</p>
-            </li>
-            <li class="p-list__item">
-              <h3 class="p-heading--5 u-no-margin--bottom">
-                <a href="https://www.w3.org/WAI/WCAG22/quickref/">How to Meet WCAG 2.2</a>
-              </h3>
-              <p>A customisable quick reference, includes guidelines, success criteria and techniques</p>
-            </li>
-            <li class="p-list__item">
-              <h3 class="p-heading--5 u-no-margin--bottom">
-                <a href="https://www.w3.org/WAI/WCAG22/Techniques/">Techniques for WCAG 2.2</a>
-              </h3>
-              <p>Instructions for developers, includes browser and assistive technology support notes, examples, code, resources and test procedures</p>
-            </li>
-          </ul>
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Key WCAG documents</h2>
+        <p>
+          The volume of information on the WCAG website can be disorienting.
+          <br />
+          We keep the following links handy for quick reference:
+        </p>
       </div>
+
+      <div class="col">
+        <ul class="p-list--divided u-no-margin--bottom">
+          <li class="p-list__item">
+            <h3 class="p-heading--5 u-no-margin--bottom">
+              <a href="https://www.w3.org/TR/WCAG22/">WCAG 2.2</a>
+            </h3>
+            <p>The W3C standard, includes principles, guidelines and success criteria</p>
+          </li>
+          <li class="p-list__item">
+            <h3 class="p-heading--5 u-no-margin--bottom">
+              <a href="https://www.w3.org/WAI/WCAG22/Understanding/">Understanding WCAG 2.2</a>
+            </h3>
+            <p>Detailed reference, includes intent, benefits to people with disabilities, examples, resources and techniques</p>
+          </li>
+          <li class="p-list__item">
+            <h3 class="p-heading--5 u-no-margin--bottom">
+              <a href="https://www.w3.org/WAI/WCAG22/quickref/">How to Meet WCAG 2.2</a>
+            </h3>
+            <p>A customizable quick reference, includes guidelines, success criteria and techniques</p>
+          </li>
+          <li class="p-list__item">
+            <h3 class="p-heading--5 u-no-margin--bottom">
+              <a href="https://www.w3.org/WAI/WCAG22/Techniques/">Techniques for WCAG 2.2</a>
+            </h3>
+            <p>Instructions for developers, includes browser and assistive technology support notes, examples, code, resources and test procedures</p>
+          </li>
+        </ul>
       </div>
     </div>
   </div>

--- a/templates/design-practice/accessibility.html
+++ b/templates/design-practice/accessibility.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
 {% block meta_title %}
-  Brand accessibility
+  Accessibility
 {% endblock meta_title %}
 
 {% block meta_description %}
-  Canonical brand accessibility
+  Canonical accessibility
 {% endblock meta_description %}
 
 {% block meta_copydoc %}
@@ -27,8 +27,8 @@
         <p>
           We aim for Level AA conformance with the
           <br />
-          <a class="p-link--inverted" href="https://www.w3.org/TR/WCAG21/">Web Content
-          Accessibility Guidelines (WCAG) 2.1</a>
+          <a href="https://www.w3.org/TR/WCAG22/">Web Content
+          Accessibility Guidelines (WCAG) 2.2</a>
         </p>
       </div>
     </div>
@@ -38,24 +38,20 @@
     <div class="row--50-50">
       <hr class="p-rule" />
       <div class="col">
-        <h2>Ensuring conformance</h2>
-        <p>We use the following tools to continually audit the framework:</p>
+        <h2>In-depth guides</h2>
       </div>
       <div class="col">
         <p class="p-heading--5 u-no-margin--bottom">
-          <a href="https://www.w3.org/WAI/eval/report-tool/#!/evaluation/audit">Accessibility report tool</a>
+          <a href="https://vanillaframework.io/docs/accessibility">Web interface accessibility guide</a>
         </p>
         <p>
-          A checklist that can be filtered by A / AA / AAA level, with a short description and links to the related "Understanding" and "How to Meet" articles that accompany each criterion.
+          Learn to make your web applications and content websites accessible, whether you are using <a href="https://vanillaframework.io">Vanilla</a> or not. Includes guidance for assistive technologies in major desktop platforms.
         </p>
         <p class="p-heading--5 u-no-margin--bottom">
-          <a href="https://www.w3.org/TR/wai-aria-practices">WAI-ARIA Authoring Practices 1.1</a>
+          <a href="https://documentation.ubuntu.com/project/contributors/check-accessibility/">Ubuntu Desktop accessibility guide</a>
         </p>
         <p>
-          <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> A guide for understanding how to use <cite><a href="https://www.w3.org/TR/wai-aria-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.1</a></cite> to create an accessible Rich Internet Application. It provides guidance on the appropriate application of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, describes recommended <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> usage patterns, and explains concepts behind them.
-        </p>
-        <p class="p-heading--5 u-no-margin--bottom">
-          <a href="https://validator.w3.org/nu/">The W3 Markup Validation Service</a>
+          Address common accessibility pitfalls in apps and interfaces on Ubuntu, so we can deliver on our mission to enable every computer user to use all software regardless of disability.
         </p>
       </div>
     </div>
@@ -103,40 +99,45 @@
         <li class="p-list__item is-ticked">HTML document should have a language attribute</li>
       </ul>
       <p>
-        *Adapted from <a href="https://accessibility.voxmedia.com">Accessibility Guidelines</a> checklist and <a href="https://a11yproject.com/checklist.html">Web Accessibility Checklist</a>
+        Adapted from <a href="https://accessibility.voxmedia.com">Accessibility Guidelines</a> checklist and <a href="https://a11yproject.com/checklist.html">Web Accessibility Checklist</a>
       </p>
     </div>
   </div>
 
   <div class="p-section">
-    <div class="p-section--shallow">
+    <div class="row--50-50">
       <div class="row">
         <hr class="p-rule" />
         <div class="col-6">
           <h2>Key WCAG documents</h2>
           <p>
-            The volume of information on the WCAG 2.0 website can be disorienting.
+            The volume of information on the WCAG website can be disorienting.
             <br />
             We keep the following links handy for quick reference:
           </p>
         </div>
+
+        <div class="col-6">        
+          <p class="p-heading--5 u-no-margin--bottom">
+            <a href="https://www.w3.org/TR/WCAG22/">WCAG 2.2</a>
+          </p>
+          <p>The W3C standard, includes principles, guidelines and success criteria</p>
+
+          <p class="p-heading--5 u-no-margin--bottom">
+            <a href="https://www.w3.org/WAI/WCAG22/Understanding/">Understanding WCAG 2.2</a>
+          </p>
+          <p>Detailed reference, includes intent, benefits to people with disabilities, examples, resources and techniques</p>
+
+          <p class="p-heading--5 u-no-margin--bottom">
+            <a href="https://www.w3.org/WAI/WCAG22/quickref/">How to Meet WCAG 2.2</a>
+          </p>
+          <p>A customisable quick reference, includes guidelines, success criteria and techniques</p>
+
+          <p class="p-heading--5 u-no-margin--bottom">
+            <a href="https://www.w3.org/WAI/WCAG22/Techniques/">Techniques for WCAG 2.2</a></p>
+          <p>Instructions for developers, includes browser and assistive technology support notes, examples, code, resources and test procedures</p>
       </div>
-    </div>
-    <div class="u-fixed-width">
-      <ul class="p-list is-split">
-        <li class="p-list__item">
-          <a href="https://www.w3.org/TR/WCAG20/">WCAG 2.0</a>: the W3C standard, includes principles, guidelines and success criteria
-        </li>
-        <li class="p-list__item">
-          <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/">Understanding WCAG 2.0</a>: detailed reference, includes intent, benefits to people with disabilities, examples, resources and techniques
-        </li>
-        <li class="p-list__item">
-          <a href="https://www.w3.org/WAI/WCAG20/quickref/">How to Meet WCAG 2.0</a>: a customisable quick reference, includes guidelines, success criteria and techniques
-        </li>
-        <li class="p-list__item">
-          <a href="https://www.w3.org/TR/WCAG20-TECHS/">Techniques for WCAG 2.0</a>: instructions for developers, includes browser and assistive technology support notes, examples, code, resources and test procedures
-        </li>
-      </ul>
+      </div>
     </div>
   </div>
 

--- a/templates/design-practice/accessibility.html
+++ b/templates/design-practice/accessibility.html
@@ -17,22 +17,19 @@
 {% endblock body_class %}
 
 {% block content %}
-
-  <div class="p-suru--50-50">
-    <div class="row--50-50">
-      <div class="col">
-        <h1>Accessibility</h1>
-      </div>
-      <div class="col">
-        <p>
-          We aim for Level AA conformance with the
-          <br />
-          <a href="https://www.w3.org/TR/WCAG22/">Web Content
-          Accessibility Guidelines (WCAG) 2.2</a>
-        </p>
+  <section class="p-suru--25-75">
+    <div class="p-section">
+      <div class="row--50-50">
+        <div class="col">
+          <h1>Accessibility at Canonical</h1>
+        </div>
+        <div class="col">
+          <p>We build our products with accessibility in mind, delivering on <a href="https://ubuntu.com/community/docs/ethos/mission">Ubuntu's mission</a> to enable every computer user to use all software regardless of disability.</p>
+          <p>We aim for Level AA conformance with the <a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines (WCAG) 2.2</a>.</p>
+        </div>
       </div>
     </div>
-  </div>
+  </section>
 
   <div class="p-section">
     <div class="row--50-50">
@@ -41,18 +38,24 @@
         <h2>In-depth guides</h2>
       </div>
       <div class="col">
-        <p class="p-heading--5 u-no-margin--bottom">
-          <a href="https://vanillaframework.io/docs/accessibility">Web interface accessibility guide</a>
-        </p>
-        <p>
-          Learn to make your web applications and content websites accessible, whether you are using <a href="https://vanillaframework.io">Vanilla</a> or not. Includes guidance for assistive technologies in major desktop platforms.
-        </p>
-        <p class="p-heading--5 u-no-margin--bottom">
-          <a href="https://documentation.ubuntu.com/project/contributors/check-accessibility/">Ubuntu Desktop accessibility guide</a>
-        </p>
-        <p>
-          Address common accessibility pitfalls in apps and interfaces on Ubuntu, so we can deliver on our mission to enable every computer user to use all software regardless of disability.
-        </p>
+        <ul class="p-list--divided u-no-margin--bottom">
+          <li class="p-list__item">
+            <h3 class="p-heading--5 u-no-margin--bottom">
+              <a href="https://vanillaframework.io/docs/accessibility">Web interface accessibility guide</a>
+            </h3>
+            <p>
+              Learn to make your web applications and content websites accessible, whether you are using <a href="https://vanillaframework.io">Vanilla</a> or not. It includes guidance for assistive technologies in major desktop platforms.
+            </p>
+          </li>
+          <li class="p-list__item">
+            <h3 class="p-heading--5 u-no-margin--bottom">
+              <a href="https://documentation.ubuntu.com/project/contributors/check-accessibility/">Ubuntu Desktop accessibility guide</a>
+            </h3>
+            <p>
+              Address common accessibility pitfalls in apps and interfaces on Ubuntu. It includes guidance for Ubuntu-specific assistive technologies, such as the Orca screen reader.
+            </p>
+          </li>
+        </ul>
       </div>
     </div>
   </div>
@@ -117,25 +120,33 @@
           </p>
         </div>
 
-        <div class="col-6">        
-          <p class="p-heading--5 u-no-margin--bottom">
-            <a href="https://www.w3.org/TR/WCAG22/">WCAG 2.2</a>
-          </p>
-          <p>The W3C standard, includes principles, guidelines and success criteria</p>
-
-          <p class="p-heading--5 u-no-margin--bottom">
-            <a href="https://www.w3.org/WAI/WCAG22/Understanding/">Understanding WCAG 2.2</a>
-          </p>
-          <p>Detailed reference, includes intent, benefits to people with disabilities, examples, resources and techniques</p>
-
-          <p class="p-heading--5 u-no-margin--bottom">
-            <a href="https://www.w3.org/WAI/WCAG22/quickref/">How to Meet WCAG 2.2</a>
-          </p>
-          <p>A customisable quick reference, includes guidelines, success criteria and techniques</p>
-
-          <p class="p-heading--5 u-no-margin--bottom">
-            <a href="https://www.w3.org/WAI/WCAG22/Techniques/">Techniques for WCAG 2.2</a></p>
-          <p>Instructions for developers, includes browser and assistive technology support notes, examples, code, resources and test procedures</p>
+        <div class="col-6">
+          <ul class="p-list--divided u-no-margin--bottom">
+            <li class="p-list__item">
+              <h3 class="p-heading--5 u-no-margin--bottom">
+                <a href="https://www.w3.org/TR/WCAG22/">WCAG 2.2</a>
+              </h3>
+              <p>The W3C standard, includes principles, guidelines and success criteria</p>
+            </li>
+            <li class="p-list__item">
+              <h3 class="p-heading--5 u-no-margin--bottom">
+                <a href="https://www.w3.org/WAI/WCAG22/Understanding/">Understanding WCAG 2.2</a>
+              </h3>
+              <p>Detailed reference, includes intent, benefits to people with disabilities, examples, resources and techniques</p>
+            </li>
+            <li class="p-list__item">
+              <h3 class="p-heading--5 u-no-margin--bottom">
+                <a href="https://www.w3.org/WAI/WCAG22/quickref/">How to Meet WCAG 2.2</a>
+              </h3>
+              <p>A customisable quick reference, includes guidelines, success criteria and techniques</p>
+            </li>
+            <li class="p-list__item">
+              <h3 class="p-heading--5 u-no-margin--bottom">
+                <a href="https://www.w3.org/WAI/WCAG22/Techniques/">Techniques for WCAG 2.2</a>
+              </h3>
+              <p>Instructions for developers, includes browser and assistive technology support notes, examples, code, resources and test procedures</p>
+            </li>
+          </ul>
       </div>
       </div>
     </div>

--- a/templates/design-practice/accessibility.html
+++ b/templates/design-practice/accessibility.html
@@ -24,7 +24,7 @@
           <h1>Accessibility at Canonical</h1>
         </div>
         <div class="col">
-          <p>We build our products with accessibility in mind, delivering on <a href="https://ubuntu.com/community/docs/ethos/mission">Ubuntu's mission</a> to enable every computer user to use all software regardless of disability.</p>
+          <p>We design products with accessibility in mind, supporting <a href="https://ubuntu.com/community/docs/ethos/mission">Ubuntu's mission</a> to make software accessible to every user regardless of disability.</p>
           <p>We aim for Level AA conformance with the <a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines (WCAG) 2.2</a>.</p>
         </div>
       </div>
@@ -44,7 +44,7 @@
               <a href="https://vanillaframework.io/docs/accessibility">Web interface accessibility guide</a>
             </h3>
             <p>
-              Learn to make your web applications and content websites accessible, whether you are using <a href="https://vanillaframework.io">Vanilla</a> or not. It includes guidance for assistive technologies in major desktop platforms.
+              Learn to make your web applications and content websites accessible, whether you are using the <a href="https://vanillaframework.io">Vanilla framework</a> or not. It includes guidance for assistive technologies in major desktop platforms.
             </p>
           </li>
           <li class="p-list__item">


### PR DESCRIPTION
## Done

- Move accessibility page from /brand/accessibility to /design-practice/accessibility
- Update references to WCAG 2.2
- Clean less relevant resources
- Add section with links to new Desktop and web/Vanilla guides
- Add redirections

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://canonical-design-61.demos.haus/design-practice/accessibility
    - Be sure to test on mobile, tablet and desktop screen sizes
- [Demo](https://canonical-design-61.demos.haus/design-practice/accessibility)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes # [DE-852](https://warthogs.atlassian.net/browse/DE-852)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[DE-852]: https://warthogs.atlassian.net/browse/DE-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ