### PR TITLE
fix(_email-signature.html): links appearing underlined

### DIFF
--- a/templates/shared/_email-signature.html
+++ b/templates/shared/_email-signature.html
@@ -217,23 +217,40 @@
                    padding-left:5px;
                    font-size: 0px"
             colspan="2">
-          <p style="display: inline-block;
-                    font-size:13px;
-                    line-height:17px;
-                    padding-top:0.8px;
-                    margin-bottom: 0px;
-                    margin-top:8px;
-                    font-weight:500">
-            <a href="https://canonical.com/careers?utm_source=signature&utm_medium=email"
-               target="_blank"
-               style="color:#0066cc; 
-                      text-decoration: none">We are hiring</a>
-            <span style="color: #757575;">|</span>
-            <a href="https://www.linkedin.com/company/canonical/life/"
-               target="_blank"
-               style="color:#0066cc; 
-                      text-decoration: none">Life at Canonical</a>
-          </p>
+          <a href="https://canonical.com/careers?utm_source=signature&utm_medium=email"
+             target="_blank"
+             style="color:#0066cc; 
+                    text-decoration: none">
+            <p style="display: inline-block;
+                      font-size:13px;
+                      line-height:17px;
+                      padding-top:0.8px;
+                      margin-bottom: 0px;
+                      margin-top:8px;
+                      font-weight:500">We are hiring</p>
+          </a>
+          <span style="display: inline-block;
+                       font-size:13px;
+                       line-height:17px;
+                       padding-top:0.8px;
+                       padding-left: 3px;
+                       padding-right: 3px;
+                       margin-bottom: 0px;
+                       margin-top:8px;
+                       font-weight:500;
+                       color: #757575;">|</span>
+          <a href="https://www.linkedin.com/company/canonical/life/"
+             target="_blank"
+             style="color:#0066cc; 
+                    text-decoration: none">
+            <p style="display: inline-block;
+                      font-size:13px;
+                      line-height:17px;
+                      padding-top:0.8px;
+                      margin-bottom: 0px;
+                      margin-top:8px;
+                      font-weight:500">Life at Canonical</p>
+          </a>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Problem statement

- On some browsers the 'Life and Canonical' and 'We are hiring' links appeared underlined. See [ticket](https://warthogs.atlassian.net/browse/WD-33997) for more details

## Done

- I have updated the HTML structure to match the canonical.com and ubuntu.com links that are not aligned.

## QA

- Check out this feature branch locally and `dotrun`
- Go to http://0.0.0.0:8052/brand/resources
- Check it matches the design on https://canonical.design/brand/resources

## Issue / Card

Fixes [# [WD-](https://warthogs.atlassian.net/browse/WD-)](https://warthogs.atlassian.net/browse/WD-33997)

