### PR TITLE
feat(WD-36402): copy update /brand/resources

### DIFF
--- a/templates/brand/resources.html
+++ b/templates/brand/resources.html
@@ -171,39 +171,14 @@
     <div class="row--50-50">
       <hr class="p-rule" />
       <div class="col">
-        <h3 class="p-heading--2" id="logos">Logos</h3>
+        <h3 class="p-heading--2">Logos</h3>
       </div>
       <div class="col">
-        <label class="p-switch">
-          <input type="checkbox"
-                 class="p-switch__input"
-                 role="switch"
-                 id="logo_switch"
-                 onchange="switchLogoThumbTheme()" />
-          <span class="p-switch__slider"></span>
-          <span class="p-switch__label">Dark mode</span>
-        </label>
-
-        <div class="u-no-margin--bottom resources__content-thumb"
-             id="logo_content_thumb">
-          {% for item in resources_data.logos %}
-            <div class="light_strip">
-              <a href="{{ item.svg_link_light }}" target="_blank">
-                <img class="resources_logo"
-                     src="{{ item.svg_link_light }}"
-                     alt="{{ item.name }}" />
-              </a>
-            </div>
-            <div class="resources__dark_mode dark_strip u-hide">
-              <a href="{{ item.svg_link_dark }}" target="_blank">
-                <img class="resources_logo"
-                     src="{{ item.svg_link_dark }}"
-                     alt="{{ item.name }}" />
-              </a>
-            </div>
-            {% if loop.index < resources_data.logos|length %}<hr class="u-no-margin--top logo_separator" />{% endif %}
-          {% endfor %}
-        </div>
+        <p>
+          Access all Canonical logos in the <a
+            href="https://drive.google.com/drive/folders/1I6Oi39qKONRN3gjNKLtovUUtwu8YYwEf"
+          >Canonical Brand Resources Drive</a>. This Drive folder allows for public access and can be shared with clients, partners, and organizations.
+        </p>
       </div>
     </div>
 
@@ -239,39 +214,6 @@
   </div>
 
   <script>
-    const switchLogoThumbTheme = () => {
-      const switchLogo = document.querySelector("#logo_switch");
-      const logoContentThumb = document.querySelector("#logo_content_thumb");
-      const darkStrip = document.querySelectorAll(".dark_strip");
-      const lightStrip = document.querySelectorAll(".light_strip");
-      const separators = document.querySelectorAll(".logo_separator");
-
-      if (switchLogo.checked) {
-        darkStrip.forEach((item) => {
-          item.classList.remove("u-hide");
-        });
-        lightStrip.forEach((item) => {
-          item.classList.add("u-hide");
-        });
-        separators.forEach((item) => {
-          item.classList.add("is-dark");
-        });
-        logoContentThumb.classList.add("resources__dark_mode");
-
-      } else {
-        darkStrip.forEach((item) => {
-          item.classList.add("u-hide");
-        });
-        lightStrip.forEach((item) => {
-          item.classList.remove("u-hide");
-        });
-        separators.forEach((item) => {
-          item.classList.remove("is-dark");
-        });
-        logoContentThumb.classList.remove("resources__dark_mode");
-      }
-    };
-
     const switchIconThumbTheme = () => {
       const switchIcon = document.querySelector("#icon_switch");
       const iconContentThumb = document.querySelector("#icon_content_thumb");


### PR DESCRIPTION
## Done

- Replace logos section with text and link to G-Drive in `/brand/resources`
  - [Copy doc](https://docs.google.com/document/d/1lhk5KwzsG1kkL1p1Ge5N8x33Y7TpKL4dHjZPCFaXbs4/edit?tab=t.0)

## QA

- Go to [/brand/resources](https://canonical-design-68.demos.haus/brand/resources)
- Cross check logos section with [copy doc](https://docs.google.com/document/d/1lhk5KwzsG1kkL1p1Ge5N8x33Y7TpKL4dHjZPCFaXbs4/edit?tab=t.0)

## Issue / Card

Fixes [WD-36402](https://warthogs.atlassian.net/browse/WD-36402)

## Screenshots

### Before
<img width="2145" height="517" alt="image" src="https://github.com/user-attachments/assets/bbd1a2b8-fbdf-4866-baf9-fe91df55190d" />

### After
<img width="2145" height="517" alt="image" src="https://github.com/user-attachments/assets/f8d13ff3-5c3f-4898-a4c5-760b061f315b" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-36402]: https://warthogs.atlassian.net/browse/WD-36402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ