### PR TITLE
remove slide template from /brand/resources

### DIFF
--- a/templates/brand/resources.html
+++ b/templates/brand/resources.html
@@ -143,30 +143,6 @@
       </div>
     </div>
 
-    <!-- SLIDES -->
-    <div class="row--50-50">
-      <hr class="p-rule" />
-      <div class="col">
-        <h3 class="p-heading--2">Slide template</h3>
-      </div>
-      <div class="col">
-        <div class="p-media-container">
-
-          <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_802,h_451/https://assets.ubuntu.com/v1/b28a9bc4-slide-deck-preview.png"
-               srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_1604,h_902/https://assets.ubuntu.com/v1/b28a9bc4-slide-deck-preview.png 2x"
-               alt=""
-               width="802"
-               height="451"
-               loading="lazy" />
-        </div>
-
-        <p>Use this template to create presentations with the Canonical branding style.</p>
-        <p>
-          <a href="https://docs.google.com/presentation/u/0/?tgif=d&ftv=1">Use the slide template (internal)</a>
-        </p>
-      </div>
-    </div>
-
     <!-- LOGOS -->
     <div class="row--50-50">
       <hr class="p-rule" />


### PR DESCRIPTION
## Done

- Removed slide template section from /brand/resources

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8052/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [Demo](https://canonical-design-XXX.demos.haus/)
- Visit /brand/resources
- Slide template section should not be there 

## Issue / Card

Fixes # [WD-37318](https://warthogs.atlassian.net/browse/WD-37318)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-37318]: https://warthogs.atlassian.net/browse/WD-37318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ